### PR TITLE
Fix samples URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ You may use the client id and secret above for demonstration purposes.
 
 ## Samples
 
-You can start off by trying out [/Payouts-DotNet-SDK/tree/master/Samples]().
+You can start off by trying out [/Payouts-DotNet-SDK/tree/master/Samples](https://github.com/paypal/Payouts-DotNet-SDK/tree/master/Samples).
 
 Note: Update the `PayPalClient.cs` with your sandbox client credentials or pass your client credentials as environment variable while executing the samples.
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ You may use the client id and secret above for demonstration purposes.
 
 ## Samples
 
-You can start off by trying out [/Payouts-SDK/Payouts-DotNet/Samples]().
+You can start off by trying out [/Payouts-DotNet-SDK/tree/master/Samples]().
 
 Note: Update the `PayPalClient.cs` with your sandbox client credentials or pass your client credentials as environment variable while executing the samples.
 


### PR DESCRIPTION
Currently, URL is not defined properly and gives a 404. No URL is explicitly specified, so it redirects here: https://github.com/nechemiaseif/Payouts-DotNet-SDK/blob/master

Fixed URL to point to samples directory in repo: https://github.com/paypal/Payouts-DotNet-SDK/tree/master/Samples